### PR TITLE
Github Actions: Another test to check the actions run with original code

### DIFF
--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -140,11 +140,11 @@ async function buildMilestoneInfo( octokit, owner, repo, number ) {
 	for await ( const plugin of plugins ) {
 		const nextMilestone = await getNextValidMilestone( octokit, owner, repo, plugin );
 		debug( `check-description: Milestone found: ${ JSON.stringify( nextMilestone ) }` );
-		if ( plugin !== 'crm' ) {
-			debug( `check-description: getting milestone info for ${ plugin }` );
-			const info = await getMilestoneDates( plugin, nextMilestone );
-	
-			pluginInfo += info;
+
+		debug( `check-description: getting milestone info for ${ plugin }` );
+		const info = await getMilestoneDates( plugin, nextMilestone );
+
+		pluginInfo += info;
 		}
 	}
 


### PR DESCRIPTION
As with the title - the github-actions bot comments are not running, so this is an attempt to make sure the code is as it was before, in order to discount my changes as the cause.
