### PR TITLE
Fixing an issue with duplicated code created during a master merge

### DIFF
--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -192,27 +192,6 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[CRM] API' );
 		}
 
-		// mu wpcom features.
-		const muWpcomFeatures = file.match(
-			/^projects\/packages\/jetpack-mu-wpcom\/src\/features\/(?<muWpcomFeature>[^/]*)\//
-		);
-		const muWpcomFeatureName = muWpcomFeatures && muWpcomFeatures.groups.muWpcomFeature;
-		if ( muWpcomFeatureName ) {
-			keywords.add( `[mu wpcom Feature] ${ cleanName( muWpcomFeatureName ) }` );
-		}
-
-		// CRM elements.
-		const crmModules = file.match( /^projects\/plugins\/crm\/modules\/(?<crmModule>[^/]*)\// );
-		const crmModuleName = crmModules && crmModules.groups.crmModule;
-		if ( crmModuleName ) {
-			keywords.add( `[CRM] ${ cleanName( crmModuleName ) } Module` );
-		}
-
-		const crmApi = file.match( /^projects\/plugins\/crm\/api\// );
-		if ( crmApi !== null ) {
-			keywords.add( '[CRM] API' );
-		}
-
 		// Boost Critical CSS.
 		const boostModules = file.match(
 			/^projects\/plugins\/boost\/app\/(?:modules|features)\/(?<boostModule>[^/]*)\//


### PR DESCRIPTION
The reason the previous PR tests were failing was due to duplicated code that must have happened during a master merge - this PR removes that code.
